### PR TITLE
[BUG] Remove client.connect()

### DIFF
--- a/bridge/mqtt/main.go
+++ b/bridge/mqtt/main.go
@@ -97,7 +97,6 @@ func (client mqttClient) handleConnect(_ paho.Client) {
 func (client *mqttClient) handleDisconnect(_ paho.Client, err error) {
 	client.logger.Errorf("handleDisconnect invoked with error: %s", err)
 	client.logger.Info("Reconnecting to broker.")
-	client.connect()
 }
 
 func (client mqttClient) unsubscribe() {


### PR DESCRIPTION
**Describe the bug**
Metamorphosis container crash if there is a socket error between the MQTT broker and itself.

```
time="2022-04-04T07:37:59Z" level=error msg="handleDisconnect invoked with error: EOF" module=mqtt
time="2022-04-04T07:37:59Z" level=info msg="Reconnecting to broker." module=mqtt
time="2022-04-04T07:37:59Z" level=info msg="MQTT client connection attempt 0: connect to broker mqtt-dev.ecomon.no:8883 (tls: true)." module=mqtt
panic: close of closed channel <--------

goroutine 74940 [running]:
github.com/eclipse/paho%2emqtt%2egolang.(*client).startCommsWorkers.func2(0xc00000e430, 0xc00000e438, 0xc0004188a0, 0xc0000c46c0)
    /go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.3.4/client.go:622 +0x32f
created by github.com/eclipse/paho%2emqtt%2egolang.(*client).startCommsWorkers
    /go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.3.4/client.go:597 +0x4b3

```
**To Reproduce**
Steps to reproduce the behavior:
Now sure what caused these socket connection interruptions, but it happens randomly in our pipe.

**Expected behavior**
It should reconnect without crashing.

**Fix**
Remove `client.connect()` from `bridge/mqtt/main.go` since the lib has a built-in reconnect. Been running for hours now without any issue.
